### PR TITLE
Supply Perl_do_ncmp for newer perls

### DIFF
--- a/XS.xs
+++ b/XS.xs
@@ -9,6 +9,10 @@
 #define iLeftChild(i)   ((2*(i)) + 1)
 #define iRightChild(i)  ((2*(i)) + 2)
 
+#ifndef Perl_do_ncmp
+    #define Perl_do_ncmp(child, parent) (SvNV(child) - SvNV(parent))
+#endif
+
 #define OUT_OF_ORDER(a,tmpsv,child_is_magic,parent_is_magic,child,parent,is_min)                \
     ( ( ( (child_is_magic) || (parent_is_magic) )                                               \
         ? (((tmpsv) = amagic_call((a)[(child)], (a)[(parent)], is_min & 2 ? sgt_amg : gt_amg, 0)) && SvTRUE((tmpsv)))  \


### PR DESCRIPTION
Low-effort fix, macro does not care to yield exactly 1, 0 or -1, since we only check `> 0`. Similar to how ppport supplies newer symbols for older perls. Causes tests to pass on my 5.42.

resolves #2